### PR TITLE
Transform test data

### DIFF
--- a/expand-jsonld-test-data-files.js
+++ b/expand-jsonld-test-data-files.js
@@ -1,0 +1,36 @@
+"use strict";
+
+const fs = require('fs');
+const jsonld = require("jsonld");
+
+
+const expandJsonLD = (path) => {
+
+    fs.readdir(path, (err, files) => {
+
+        files.forEach(
+            (jsondldFilename, index) => {
+
+
+                const jsonldFile = fs.readFileSync(path + jsondldFilename, 'utf8', 'r+');
+
+                const expandedPromise = jsonld.compact(JSON.parse(jsonldFile), {});
+                expandedPromise.then(
+                    expanded => {
+                        // write fo file with "expanded" suffix
+                        fs.writeFileSync( path + jsondldFilename.substring(0, jsondldFilename.length-5) + "-expanded.json", JSON.stringify(expanded), "utf8");
+                    },
+                    err => {
+                        console.log("JSONLD failed " + jsondldFilename + " \n" + err);
+                    }
+                );
+            }
+        );
+
+    });
+};
+
+const ontologiesPath = "test/data/api/v2/ontologies/";
+// const resourcesPath = "test/data/api/v2/resources/";
+
+expandJsonLD(ontologiesPath);

--- a/expand-jsonld-test-data-files.js
+++ b/expand-jsonld-test-data-files.js
@@ -11,19 +11,23 @@ const expandJsonLD = (path) => {
         files.forEach(
             (jsondldFilename, index) => {
 
+                if (jsondldFilename.endsWith(".json") && jsondldFilename.indexOf("expanded") === -1) {
 
-                const jsonldFile = fs.readFileSync(path + jsondldFilename, 'utf8', 'r+');
+                    // console.log(jsondldFilename + " " + jsondldFilename.indexOf("expanded"))
 
-                const expandedPromise = jsonld.compact(JSON.parse(jsonldFile), {});
-                expandedPromise.then(
-                    expanded => {
-                        // write fo file with "expanded" suffix
-                        fs.writeFileSync( path + jsondldFilename.substring(0, jsondldFilename.length-5) + "-expanded.json", JSON.stringify(expanded), "utf8");
-                    },
-                    err => {
-                        console.log("JSONLD failed " + jsondldFilename + " \n" + err);
-                    }
-                );
+                    const jsonldFile = fs.readFileSync(path + jsondldFilename, 'utf8', 'r+');
+
+                    const expandedPromise = jsonld.compact(JSON.parse(jsonldFile), {});
+                    expandedPromise.then(
+                        expanded => {
+                            // write fo file with "expanded" suffix
+                            // fs.writeFileSync(path + jsondldFilename.substring(0, jsondldFilename.length - 5) + "-expanded.json", JSON.stringify(expanded), "utf8");
+                        },
+                        err => {
+                            console.log("JSONLD failed " + jsondldFilename + " \n" + err);
+                        }
+                    );
+                }
             }
         );
 

--- a/expand-jsonld-test-data-files.js
+++ b/expand-jsonld-test-data-files.js
@@ -21,7 +21,7 @@ const expandJsonLD = (path) => {
                     expandedPromise.then(
                         expanded => {
                             // write fo file with "expanded" suffix
-                            // fs.writeFileSync(path + jsondldFilename.substring(0, jsondldFilename.length - 5) + "-expanded.json", JSON.stringify(expanded), "utf8");
+                            fs.writeFileSync(path + jsondldFilename.substring(0, jsondldFilename.length - 5) + "-expanded.json", JSON.stringify(expanded), "utf8");
                         },
                         err => {
                             console.log("JSONLD failed " + jsondldFilename + " \n" + err);
@@ -35,6 +35,7 @@ const expandJsonLD = (path) => {
 };
 
 const ontologiesPath = "test/data/api/v2/ontologies/";
-// const resourcesPath = "test/data/api/v2/resources/";
+const resourcesPath = "test/data/api/v2/resources/";
 
 expandJsonLD(ontologiesPath);
+expandJsonLD(resourcesPath);

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "index.js"
   ],
   "scripts": {
+    "expand": "node expand-jsonld-test-data-files.js",
     "test": "karma start karma.conf.js",
     "build": "tsc && mkdir -p build/ && cp CHANGELOG.md build/ && cp LICENSE build/ && cp README.md build/ && cp package.json build/",
     "yalc-publish": "npm run build && yalc publish build/ --push",


### PR DESCRIPTION
This PR automatically expands the prefixes of JSONLD. Like this, mocked services can use this JSONLD directly without having to deal with the extra complexity of using the jsonld processor. 